### PR TITLE
FileQuestion / ImageConstraintの実装改築

### DIFF
--- a/svc/pkg/domain/model/question/checkbox.go
+++ b/svc/pkg/domain/model/question/checkbox.go
@@ -93,7 +93,7 @@ func ImportCheckBoxQuestion(q StandardQuestion) (*CheckBoxQuestion, error) {
 	return NewCheckBoxQuestion(q.ID, q.Text, options, optionsOrder, q.FormID), nil
 }
 
-func (q CheckBoxQuestion) Export() StandardQuestion {
+func (q CheckBoxQuestion) Export() (*StandardQuestion, error) {
 	customs := make(map[string]interface{})
 	options := make(map[string]string, len(q.Options))
 	for _, option := range q.Options {
@@ -105,7 +105,7 @@ func (q CheckBoxQuestion) Export() StandardQuestion {
 	}
 	customs[CheckBoxOptionsField] = options
 	customs[CheckBoxOptionsOrderField] = optionsOrder
-	return NewStandardQuestion(TypeCheckBox, q.ID, q.FormID, q.Text, customs)
+	return NewStandardQuestion(TypeCheckBox, q.ID, q.FormID, q.Text, customs), nil
 }
 
 func (o CheckboxOptionsOrder) GetOrderedIDs() []CheckBoxOptionID {

--- a/svc/pkg/domain/model/question/file.go
+++ b/svc/pkg/domain/model/question/file.go
@@ -9,8 +9,8 @@ import (
 type (
 	FileQuestion struct {
 		Basic
-		FileTypes  FileTypes
-		Constraint FileConstraint
+		FileTypes   FileTypes
+		Constraints map[FileType]FileConstraint
 	}
 	FileTypes struct {
 		AcceptAny   bool
@@ -25,12 +25,12 @@ const (
 )
 
 func NewFileQuestion(
-	id id.QuestionID, text string, fileTypes FileTypes, constraint FileConstraint, formID id.FormID,
+	id id.QuestionID, text string, fileTypes FileTypes, constraint map[FileType]FileConstraint, formID id.FormID,
 ) *FileQuestion {
 	return &FileQuestion{
-		Basic:      NewBasic(id, text, TypeFile, formID),
-		FileTypes:  fileTypes,
-		Constraint: constraint,
+		Basic:       NewBasic(id, text, TypeFile, formID),
+		FileTypes:   fileTypes,
+		Constraints: constraint,
 	}
 }
 
@@ -62,20 +62,39 @@ func ImportFileQuestion(q StandardQuestion) (*FileQuestion, error) {
 	}
 
 	constraintsCustomsData, has := q.Customs[FileConstraintsCustomsField]
-	// if FileConstraintsCustomsField is not present, return FileQuestion without constraint
+	//if FileConstraintsCustomsField is not present, return FileQuestion without constraint
 	if !has {
 		return NewFileQuestion(q.ID, q.Text, fileTypes, nil, q.FormID), nil
 	}
 
-	constraintsCustoms, ok := constraintsCustomsData.(map[string]interface{})
-	// if FileConstraintsCustomsField Found, but it is not map[string]interface{}, return error
+	constraintsCustoms, ok := constraintsCustomsData.([]interface{})
+	//if FileConstraintsCustomsField Found, but it is not slice, return error
 	if !ok {
 		return nil, errors.New(
 			fmt.Sprintf("\"%s\" must be map[string]interface{} for FileQuestion", FileConstraintsCustomsField))
 	}
 
-	constraint := NewStandardFileConstraint(fileTypes, constraintsCustoms)
-	question := NewFileQuestion(q.ID, q.Text, fileTypes, ImportFileConstraint(constraint), q.FormID)
+	constraints := make(map[FileType]FileConstraint, len(constraintsCustoms))
+
+	for _, constraintCustomsDataI := range constraintsCustoms {
+		constraintCustomsData, ok := constraintCustomsDataI.(map[string]interface{})
+		if !ok {
+			return nil, errors.New(
+				fmt.Sprintf("\"%s\" must be map[string]interface{} for FileQuestion", FileConstraintsCustomsField))
+		}
+
+		st, err := NewStandardFileConstraint(FileType(constraintCustomsData[FileTypeCustomField].(float64)), constraintCustomsData)
+		if err != nil {
+			return nil, fmt.Errorf("failed to import file constraint: %w", err)
+		}
+		fileType, constraint, err := ImportFileConstraint(*st)
+		if err != nil {
+			return nil, fmt.Errorf("failed to import file constraint: %w", err)
+		}
+		constraints[fileType] = constraint
+	}
+
+	question := NewFileQuestion(q.ID, q.Text, fileTypes, constraints, q.FormID)
 	return question, nil
 }
 
@@ -85,8 +104,15 @@ func (q FileQuestion) Export() (*StandardQuestion, error) {
 	qt := []bool{q.FileTypes.AcceptAny, q.FileTypes.AcceptImage, q.FileTypes.AcceptPDF}
 	customs[FileQuestionFileTypeField] = qt
 
-	if q.Constraint != nil {
-		customs[FileConstraintsCustomsField] = q.Constraint.Export().Customs
+	if q.Constraints != nil {
+		constraints := make([]map[string]interface{}, 0, len(q.Constraints))
+		for _, constraint := range q.Constraints {
+			c, err := constraint.Export()
+			if err != nil {
+				return nil, fmt.Errorf("failed to export file constraint: %w", err)
+			}
+			constraints = append(constraints, c.Customs)
+		}
 	}
 	return NewStandardQuestion(TypeFile, q.ID, q.FormID, q.Text, customs), nil
 }

--- a/svc/pkg/domain/model/question/file.go
+++ b/svc/pkg/domain/model/question/file.go
@@ -88,5 +88,6 @@ func (q FileQuestion) Export() (*StandardQuestion, error) {
 
 	qt := []bool{q.FileTypes.AcceptAny, q.FileTypes.AcceptImage, q.FileTypes.AcceptPDF}
 	customs[FileQuestionFileTypeField] = qt
+	customs[FileImageConstraintField] = q.ImageFileConstraint.Export()
 	return NewStandardQuestion(TypeFile, q.ID, q.FormID, q.Text, customs), nil
 }

--- a/svc/pkg/domain/model/question/file.go
+++ b/svc/pkg/domain/model/question/file.go
@@ -79,7 +79,7 @@ func ImportFileQuestion(q StandardQuestion) (*FileQuestion, error) {
 	return question, nil
 }
 
-func (q FileQuestion) Export() StandardQuestion {
+func (q FileQuestion) Export() (*StandardQuestion, error) {
 	customs := make(map[string]interface{})
 
 	qt := []bool{q.FileTypes.AcceptAny, q.FileTypes.AcceptImage, q.FileTypes.AcceptPDF}
@@ -88,5 +88,5 @@ func (q FileQuestion) Export() StandardQuestion {
 	if q.Constraint != nil {
 		customs[FileConstraintsCustomsField] = q.Constraint.Export().Customs
 	}
-	return NewStandardQuestion(TypeFile, q.ID, q.FormID, q.Text, customs)
+	return NewStandardQuestion(TypeFile, q.ID, q.FormID, q.Text, customs), nil
 }

--- a/svc/pkg/domain/model/question/file_constraint.go
+++ b/svc/pkg/domain/model/question/file_constraint.go
@@ -1,6 +1,7 @@
 package question
 
 type (
+	FileType               int
 	StandardFileConstraint struct {
 		Type    FileType
 		Customs map[string]interface{}
@@ -16,6 +17,11 @@ type (
 		Data     []byte
 	}
 	Extension string
+)
+
+const (
+	Image FileType = 1
+	PDF   FileType = 2
 )
 
 func NewStandardFileConstraint(fileType FileType, customs map[string]interface{}) StandardFileConstraint {

--- a/svc/pkg/domain/model/question/file_constraint.go
+++ b/svc/pkg/domain/model/question/file_constraint.go
@@ -1,5 +1,7 @@
 package question
 
+import "fmt"
+
 type (
 	FileType               int
 	StandardFileConstraint struct {
@@ -9,7 +11,7 @@ type (
 	FileConstraint interface {
 		GetFileType() FileType
 		GetExtensions() []Extension
-		Export() StandardFileConstraint
+		Export() (*StandardFileConstraint, error)
 		ValidateFiles(file []File) error
 	}
 	File struct {
@@ -20,22 +22,24 @@ type (
 )
 
 const (
-	Image FileType = 1
-	PDF   FileType = 2
+	Image               FileType = 1
+	PDF                 FileType = 2
+	FileTypeCustomField          = "type"
 )
 
-func NewStandardFileConstraint(fileType FileType, customs map[string]interface{}) StandardFileConstraint {
-	return StandardFileConstraint{
+func NewStandardFileConstraint(fileType FileType, customs map[string]interface{}) (*StandardFileConstraint, error) {
+	customs[FileTypeCustomField] = fileType
+	return &StandardFileConstraint{
 		Type:    fileType,
 		Customs: customs,
-	}
+	}, nil
 }
 
-func ImportFileConstraint(standard StandardFileConstraint) FileConstraint {
-	switch standard.Type {
+func ImportFileConstraint(st StandardFileConstraint) (FileType, FileConstraint, error) {
+	switch st.Type {
 	case Image:
-		return ImportImageFileConstraint(standard)
+		return Image, ImportImageFileConstraint(st), nil
 	default:
-		return nil
+		return 0, nil, fmt.Errorf("invalid file type")
 	}
 }

--- a/svc/pkg/domain/model/question/file_constraint.go
+++ b/svc/pkg/domain/model/question/file_constraint.go
@@ -1,7 +1,5 @@
 package question
 
-import "fmt"
-
 type (
 	FileType               int
 	StandardFileConstraint struct {
@@ -26,20 +24,3 @@ const (
 	PDF                 FileType = 2
 	FileTypeCustomField          = "type"
 )
-
-func NewStandardFileConstraint(fileType FileType, customs map[string]interface{}) (*StandardFileConstraint, error) {
-	customs[FileTypeCustomField] = fileType
-	return &StandardFileConstraint{
-		Type:    fileType,
-		Customs: customs,
-	}, nil
-}
-
-func ImportFileConstraint(st StandardFileConstraint) (FileType, FileConstraint, error) {
-	switch st.Type {
-	case Image:
-		return Image, ImportImageFileConstraint(st), nil
-	default:
-		return 0, nil, fmt.Errorf("invalid file type")
-	}
-}

--- a/svc/pkg/domain/model/question/file_constraint_image.go
+++ b/svc/pkg/domain/model/question/file_constraint_image.go
@@ -9,17 +9,6 @@ import (
 )
 
 type (
-	DimensionSpec struct {
-		Min, Max *int
-		Eq       *int
-	}
-
-	// RatioSpec represents the ratio of width / height
-	RatioSpec struct {
-		Min, Max *float32
-		Eq       *float32
-	}
-
 	ImageFileConstraint struct {
 		Ratio         RatioSpec
 		MinNumber     *int
@@ -272,76 +261,6 @@ func ImportImageFileConstraint(c map[string]interface{}) (*ImageFileConstraint, 
 	return NewImageFileConstraint(minNumber, maxNumber, width, height, ratio)
 }
 
-func loadDimensionSpec(c map[string]interface{}, key string) (DimensionSpec, error) {
-	target := DimensionSpec{}
-	t, has := c[key]
-	if !has {
-		return DimensionSpec{}, nil
-	}
-	m, ok := t.(map[string]interface{})
-	if !ok {
-		return DimensionSpec{}, errors.New("invalid dimension spec")
-	}
-	if eqR, has := m[FileImageConstraintDimensionEq]; has && eqR != nil {
-		eqV, ok := eqR.(int)
-		if !ok {
-			return DimensionSpec{}, errors.New("invalid eq dimension")
-		}
-		target.Eq = &eqV
-	} else {
-		if minR, has := m[FileImageConstraintDimensionMin]; has && minR != nil {
-			minV, ok := minR.(int)
-			if !ok {
-				return DimensionSpec{}, errors.New("invalid min dimension")
-			}
-			target.Min = &minV
-		}
-		if maxR, has := m[FileImageConstraintDimensionMax]; has && maxR != nil {
-			maxV, ok := maxR.(int)
-			if !ok {
-				return DimensionSpec{}, errors.New("invalid max dimension")
-			}
-			target.Max = &maxV
-		}
-	}
-	return target, nil
-}
-
-func loadRatioSpec(c map[string]interface{}, key string) (RatioSpec, error) {
-	target := RatioSpec{}
-	t, has := c[key]
-	if !has {
-		return RatioSpec{}, nil
-	}
-	m, ok := t.(map[string]interface{})
-	if !ok {
-		return RatioSpec{}, errors.New("invalid ratio spec")
-	}
-	if eqR, has := m[FileImageConstraintRatioEq]; has && eqR != nil {
-		eqV, ok := eqR.(float32)
-		if !ok {
-			return RatioSpec{}, errors.New("invalid eq ratio")
-		}
-		target.Eq = &eqV
-	} else {
-		if minR, has := m[FileImageConstraintRatioMin]; has && minR != nil {
-			minV, ok := minR.(float32)
-			if !ok {
-				return RatioSpec{}, errors.New("invalid min ratio")
-			}
-			target.Min = &minV
-		}
-		if maxR, has := m[FileImageConstraintRatioMax]; has && maxR != nil {
-			maxV, ok := maxR.(float32)
-			if !ok {
-				return RatioSpec{}, errors.New("invalid max ratio")
-			}
-			target.Max = &maxV
-		}
-	}
-	return target, nil
-}
-
 func loadInt(t map[string]interface{}, key string) (*int, error) {
 	v, has := t[key]
 	if !has {
@@ -366,35 +285,5 @@ func (c ImageFileConstraint) Export() map[string]interface{} {
 	result[FileImageConstraintWidth] = widthC
 	heightC := c.Height.Export()
 	result[FileImageConstraintHeight] = heightC
-	return result
-}
-
-func (s DimensionSpec) Export() map[string]interface{} {
-	result := map[string]interface{}{}
-	if s.Eq != nil {
-		result[FileImageConstraintDimensionEq] = *s.Eq
-	} else {
-		if s.Min != nil {
-			result[FileImageConstraintDimensionMin] = *s.Min
-		}
-		if s.Max != nil {
-			result[FileImageConstraintDimensionMax] = *s.Max
-		}
-	}
-	return result
-}
-
-func (s RatioSpec) Export() map[string]interface{} {
-	result := map[string]interface{}{}
-	if s.Eq != nil {
-		result[FileImageConstraintRatioEq] = *s.Eq
-	} else {
-		if s.Min != nil {
-			result[FileImageConstraintRatioMin] = *s.Min
-		}
-		if s.Max != nil {
-			result[FileImageConstraintRatioMax] = *s.Max
-		}
-	}
 	return result
 }

--- a/svc/pkg/domain/model/question/file_constraint_image.go
+++ b/svc/pkg/domain/model/question/file_constraint_image.go
@@ -67,7 +67,7 @@ func ImportImageFileConstraint(standard StandardFileConstraint) ImageFileConstra
 		ratio, int(minNumber), int(maxNumber), int(minWidth), int(maxWidth), int(minHeight), int(maxHeight), exts)
 }
 
-func (c ImageFileConstraint) Export() StandardFileConstraint {
+func (c ImageFileConstraint) Export() (*StandardFileConstraint, error) {
 	return NewStandardFileConstraint(Image,
 		map[string]interface{}{
 			"ratio":      c.Ratio,

--- a/svc/pkg/domain/model/question/file_constraint_image.go
+++ b/svc/pkg/domain/model/question/file_constraint_image.go
@@ -9,18 +9,25 @@ import (
 )
 
 type (
+	DimensionSpec struct {
+		Min, Max *int
+		Eq       *int
+	}
+
+	// RatioSpec represents the ratio of width / height
+	RatioSpec struct {
+		Min, Max *float32
+		Eq       *float32
+	}
+
 	ImageFileConstraint struct {
-		Ratio               float64
-		MinNumber           int
-		MaxNumber           int
-		MinResolutionWidth  int
-		MaxResolutionWidth  int
-		MinResolutionHeight int
-		MaxResolutionHeight int
-		Extensions          []Extension
-		PNGInfo             image.InfoExtractor
-		JPGInfo             image.InfoExtractor
-		WEBPInfo            image.InfoExtractor
+		Ratio         RatioSpec
+		MinNumber     *int
+		MaxNumber     *int
+		Width, Height DimensionSpec
+		PNGInfo       image.InfoExtractor
+		JPGInfo       image.InfoExtractor
+		WEBPInfo      image.InfoExtractor
 	}
 	ImageType int
 )
@@ -29,56 +36,35 @@ const (
 	PNG  ImageType = 1
 	JPG  ImageType = 2
 	WEBP ImageType = 3
+	TIFF ImageType = 4
+	HEIC ImageType = 5
+	SVG  ImageType = 6
 )
 
 func NewImageFileConstraint(
-	ratio float64, minNumber, maxNumber, minWidth, maxWidth, minHeight, maxHeight int, extensions []Extension,
-) ImageFileConstraint {
-	return ImageFileConstraint{
-		Ratio:               ratio,
-		MinNumber:           minNumber,
-		MaxNumber:           maxNumber,
-		MinResolutionWidth:  minWidth,
-		MaxResolutionWidth:  maxWidth,
-		MinResolutionHeight: minHeight,
-		MaxResolutionHeight: maxHeight,
-		Extensions:          extensions,
-		PNGInfo:             imagePkg.NewPNGInfo(),
-		JPGInfo:             imagePkg.NewJPEGInfo(),
-		WEBPInfo:            imagePkg.NewWEBPInfo(),
+	minNumber, maxNumber *int,
+	width, height DimensionSpec,
+	ratio RatioSpec,
+) (*ImageFileConstraint, error) {
+	if err := width.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid width: %w", err)
 	}
-}
-
-func ImportImageFileConstraint(standard StandardFileConstraint) ImageFileConstraint {
-	ratio, _ := standard.Customs["ratio"].(float64)
-	minNumber, _ := standard.Customs["minNumber"].(int64)
-	maxNumber, _ := standard.Customs["maxNumber"].(int64)
-	minWidth, _ := standard.Customs["minWidth"].(int64)
-	maxWidth, _ := standard.Customs["maxWidth"].(int64)
-	minHeight, _ := standard.Customs["minHeight"].(int64)
-	maxHeight, _ := standard.Customs["maxHeight"].(int64)
-	extsI, _ := standard.Customs["extensions"].([]interface{})
-	exts := make([]Extension, len(extsI))
-	for i, extI := range extsI {
-		exts[i] = extI.(Extension)
+	if err := height.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid height: %w", err)
 	}
-
-	return NewImageFileConstraint(
-		ratio, int(minNumber), int(maxNumber), int(minWidth), int(maxWidth), int(minHeight), int(maxHeight), exts)
-}
-
-func (c ImageFileConstraint) Export() (*StandardFileConstraint, error) {
-	return NewStandardFileConstraint(Image,
-		map[string]interface{}{
-			"ratio":      c.Ratio,
-			"minNumber":  c.MinNumber,
-			"maxNumber":  c.MaxNumber,
-			"minWidth":   c.MinResolutionWidth,
-			"maxWidth":   c.MaxResolutionWidth,
-			"minHeight":  c.MinResolutionHeight,
-			"maxHeight":  c.MaxResolutionHeight,
-			"extensions": c.Extensions,
-		})
+	if err := ratio.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid ratio: %w", err)
+	}
+	return &ImageFileConstraint{
+		Ratio:     ratio,
+		MinNumber: minNumber,
+		MaxNumber: maxNumber,
+		Width:     width,
+		Height:    height,
+		PNGInfo:   imagePkg.NewPNGInfo(),
+		JPGInfo:   imagePkg.NewJPEGInfo(),
+		WEBPInfo:  imagePkg.NewWEBPInfo(),
+	}, nil
 }
 
 func (c ImageFileConstraint) GetFileType() FileType {
@@ -86,17 +72,20 @@ func (c ImageFileConstraint) GetFileType() FileType {
 }
 
 func (c ImageFileConstraint) GetExtensions() []Extension {
-	return c.Extensions
+	return []Extension{".jpg", ".jpeg", ".png", ".webp"}
 }
 
 func (c ImageFileConstraint) ValidateFiles(files []File) error {
-	if c.MinNumber > 0 && len(files) < c.MinNumber {
-		return errors.New(fmt.Sprintf(
-			"number of files not satisfied. min number: %d, actual number: %d", c.MinNumber, len(files)))
+	if len(files) == 0 {
+		return errors.New("no file found")
 	}
-	if c.MaxNumber > 0 && len(files) > c.MaxNumber {
+	if c.MinNumber != nil && *c.MinNumber <= len(files) {
 		return errors.New(fmt.Sprintf(
-			"number of files not satisfied. max number: %d, actual number: %d", c.MaxNumber, len(files)))
+			"number of files not satisfied. min number: %d, actual number: %d", *c.MinNumber, len(files)))
+	}
+	if c.MaxNumber != nil && *c.MaxNumber >= len(files) {
+		return errors.New(fmt.Sprintf(
+			"number of files not satisfied. max number: %d, actual number: %d", *c.MaxNumber, len(files)))
 	}
 
 	for _, file := range files {
@@ -131,43 +120,61 @@ func (c ImageFileConstraint) validateProperties(imgType ImageType, file []byte) 
 	if err != nil {
 		return err
 	}
-	if c.MinResolutionWidth > 0 && width < c.MinResolutionWidth {
-		return errors.New(
-			fmt.Sprintf("width not satisfied. min width: %d, actual width: %d", c.MinResolutionWidth, width))
+	if width <= 0 || height <= 0 {
+		return errors.New("invalid image size")
 	}
-	if c.MaxResolutionWidth > 0 && width > c.MaxResolutionWidth {
-		return errors.New(
-			fmt.Sprintf("width not satisfied. max width: %d, actual width: %d", c.MaxResolutionWidth, width))
+	if err := validateDimension(c.Width, width, "width"); err != nil {
+		return err
 	}
-	if c.MinResolutionHeight > 0 && height < c.MinResolutionHeight {
-		return errors.New(
-			fmt.Sprintf("height not satisfied. min height: %d, actual height: %d", c.MinResolutionHeight, height))
+	if err := validateDimension(c.Height, height, "height"); err != nil {
+		return err
 	}
-	if c.MaxResolutionHeight > 0 && height > c.MaxResolutionHeight {
-		return errors.New(
-			fmt.Sprintf("height not satisfied. max height: %d, actual height: %d", c.MaxResolutionHeight, height))
+	if err := validateRatio(c.Ratio, float32(width)/float32(height), "ratio"); err != nil {
+		return err
 	}
-	if c.Ratio > 0 {
-		if ratio := float64(width) / float64(height); ratio != c.Ratio {
-			return errors.New(
-				fmt.Sprintf("ratio not satisfied. expected ratio: %f, actual ratio: %f", c.Ratio, ratio))
-		}
+	return nil
+}
+
+func validateDimension(d DimensionSpec, value int, name string) error {
+	if d.Min != nil && value < *d.Min {
+		return errors.New(
+			fmt.Sprintf("%s not satisfied. min %s: %d, actual %s: %d", name, name, *d.Min, name, value))
+	}
+	if d.Max != nil && value > *d.Max {
+		return errors.New(
+			fmt.Sprintf("%s not satisfied. max %s: %d, actual %s: %d", name, name, *d.Max, name, value))
+	}
+	if d.Eq != nil && value != *d.Eq {
+		return errors.New(
+			fmt.Sprintf("%s not satisfied. expected %s: %d, actual %s: %d", name, name, *d.Eq, name, value))
+	}
+	return nil
+}
+
+func validateRatio(r RatioSpec, value float32, name string) error {
+	if r.Min != nil && value < *r.Min {
+		return errors.New(
+			fmt.Sprintf("%s not satisfied. min %s: %f, actual %s: %f", name, name, *r.Min, name, value))
+	}
+	if r.Max != nil && value > *r.Max {
+		return errors.New(
+			fmt.Sprintf("%s not satisfied. max %s: %f, actual %s: %f", name, name, *r.Max, name, value))
+	}
+	if r.Eq != nil && value != *r.Eq {
+		return errors.New(
+			fmt.Sprintf("%s not satisfied. expected %s: %f, actual %s: %f", name, name, *r.Eq, name, value))
 	}
 	return nil
 }
 
 func (c ImageFileConstraint) checkExtension(ext string) (ImageType, error) {
-	if len(c.Extensions) == 0 {
-		// if extension is not specified, check with default extensions
-		return convertToImageType(ext)
-	}
-	for _, e := range c.Extensions {
+	for _, e := range c.GetExtensions() {
 		if string(e) == ext {
 			return convertToImageType(ext)
 		}
 	}
 	return 0, errors.New(
-		fmt.Sprintf("invalid file type. specified extensions: %v", c.Extensions))
+		fmt.Sprintf("invalid file type. specified extensions: %v", c.GetExtensions()))
 }
 
 func convertToImageType(ext string) (ImageType, error) {
@@ -183,4 +190,46 @@ func convertToImageType(ext string) (ImageType, error) {
 			fmt.Sprintf("invalid file type. available extensions: %v",
 				[]string{".jpg", ".jpeg", ".png", ".webp"}))
 	}
+}
+
+func (s RatioSpec) Validate() error {
+	if s.Eq != nil {
+		if *s.Eq <= 0 {
+			return errors.New("eq ratio must be positive")
+		}
+		if s.Min != nil || s.Max != nil {
+			return errors.New("eq ratio is specified with min or max ratio")
+		}
+		return nil
+	}
+
+	if s.Min != nil && *s.Min <= 0 {
+		return errors.New("min ratio must be positive")
+	}
+	if s.Max != nil && *s.Max <= 0 {
+		return errors.New("max ratio must be positive")
+	}
+	if s.Min != nil && s.Max != nil && *s.Min > *s.Max {
+		return errors.New("min ratio is greater than max ratio")
+	}
+	return nil
+}
+
+func (s DimensionSpec) Validate() error {
+	if s.Eq != nil {
+		if *s.Eq <= 0 {
+			return errors.New("eq dimension must be positive")
+		}
+		if s.Min != nil || s.Max != nil {
+			return errors.New("eq dimension is specified with min or max dimension")
+		}
+		return nil
+	}
+	if s.Min != nil && *s.Min <= 0 {
+		return errors.New("min dimension must be positive")
+	}
+	if s.Max != nil && *s.Max <= 0 {
+		return errors.New("max dimension must be positive")
+	}
+	return nil
 }

--- a/svc/pkg/domain/model/question/file_constraint_image.go
+++ b/svc/pkg/domain/model/question/file_constraint_image.go
@@ -285,5 +285,7 @@ func (c ImageFileConstraint) Export() map[string]interface{} {
 	result[FileImageConstraintWidth] = widthC
 	heightC := c.Height.Export()
 	result[FileImageConstraintHeight] = heightC
+	ratioC := c.Ratio.Export()
+	result[FileImageConstraintRatio] = ratioC
 	return result
 }

--- a/svc/pkg/domain/model/question/file_constraint_image_spec.go
+++ b/svc/pkg/domain/model/question/file_constraint_image_spec.go
@@ -1,0 +1,130 @@
+package question
+
+import "errors"
+
+type (
+	DimensionSpec struct {
+		Min, Max *int
+		Eq       *int
+	}
+
+	// RatioSpec represents the ratio of width / height
+	RatioSpec struct {
+		Min, Max *float32
+		Eq       *float32
+	}
+)
+
+func NewDimensionSpec(min, max, eq *int) DimensionSpec {
+	if eq != nil {
+		return DimensionSpec{Eq: eq}
+	}
+	return DimensionSpec{Min: min, Max: max, Eq: nil}
+}
+
+func NewRatioSpec(min, max, eq *float32) RatioSpec {
+	if eq != nil {
+		return RatioSpec{Eq: eq}
+	}
+	return RatioSpec{Min: min, Max: max, Eq: nil}
+}
+
+func (s DimensionSpec) Export() map[string]interface{} {
+	result := map[string]interface{}{}
+	if s.Eq != nil {
+		result[FileImageConstraintDimensionEq] = *s.Eq
+	} else {
+		if s.Min != nil {
+			result[FileImageConstraintDimensionMin] = *s.Min
+		}
+		if s.Max != nil {
+			result[FileImageConstraintDimensionMax] = *s.Max
+		}
+	}
+	return result
+}
+
+func (s RatioSpec) Export() map[string]interface{} {
+	result := map[string]interface{}{}
+	if s.Eq != nil {
+		result[FileImageConstraintRatioEq] = *s.Eq
+	} else {
+		if s.Min != nil {
+			result[FileImageConstraintRatioMin] = *s.Min
+		}
+		if s.Max != nil {
+			result[FileImageConstraintRatioMax] = *s.Max
+		}
+	}
+	return result
+}
+
+func loadDimensionSpec(c map[string]interface{}, key string) (DimensionSpec, error) {
+	target := DimensionSpec{}
+	t, has := c[key]
+	if !has {
+		return DimensionSpec{}, nil
+	}
+	m, ok := t.(map[string]interface{})
+	if !ok {
+		return DimensionSpec{}, errors.New("invalid dimension spec")
+	}
+	if eqR, has := m[FileImageConstraintDimensionEq]; has && eqR != nil {
+		eqV, ok := eqR.(int)
+		if !ok {
+			return DimensionSpec{}, errors.New("invalid eq dimension")
+		}
+		target.Eq = &eqV
+	} else {
+		if minR, has := m[FileImageConstraintDimensionMin]; has && minR != nil {
+			minV, ok := minR.(int)
+			if !ok {
+				return DimensionSpec{}, errors.New("invalid min dimension")
+			}
+			target.Min = &minV
+		}
+		if maxR, has := m[FileImageConstraintDimensionMax]; has && maxR != nil {
+			maxV, ok := maxR.(int)
+			if !ok {
+				return DimensionSpec{}, errors.New("invalid max dimension")
+			}
+			target.Max = &maxV
+		}
+	}
+	return target, nil
+}
+
+func loadRatioSpec(c map[string]interface{}, key string) (RatioSpec, error) {
+	target := RatioSpec{}
+	t, has := c[key]
+	if !has {
+		return RatioSpec{}, nil
+	}
+	m, ok := t.(map[string]interface{})
+	if !ok {
+		return RatioSpec{}, errors.New("invalid ratio spec")
+	}
+	if eqR, has := m[FileImageConstraintRatioEq]; has && eqR != nil {
+		eqV, ok := eqR.(float32)
+		if !ok {
+			return RatioSpec{}, errors.New("invalid eq ratio")
+		}
+		target.Eq = &eqV
+	} else {
+		if minR, has := m[FileImageConstraintRatioMin]; has && minR != nil {
+			minV, ok := minR.(float32)
+			if !ok {
+				return RatioSpec{}, errors.New("invalid min ratio")
+			}
+			target.Min = &minV
+		}
+		if maxR, has := m[FileImageConstraintRatioMax]; has && maxR != nil {
+			maxV, ok := maxR.(float32)
+			if !ok {
+				return RatioSpec{}, errors.New("invalid max ratio")
+			}
+			target.Max = &maxV
+		}
+	}
+	return target, nil
+}

--- a/svc/pkg/domain/model/question/file_test.go
+++ b/svc/pkg/domain/model/question/file_test.go
@@ -1,0 +1,126 @@
+package question
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"ynufes-mypage-backend/pkg/identity"
+)
+
+func TestImportFileQuestion(t *testing.T) {
+	f1, f2, f3 := float32(0.5), float32(1.5), float32(3.0)
+	v1, v2, v3 := 100, 200, 300
+	SampleID1, sampleID2 := identity.IssueID(), identity.IssueID()
+	tests := []struct {
+		name string
+		from StandardQuestion
+		want *FileQuestion
+	}{
+		{
+			name: "ImageQuestion - Simple",
+			from: StandardQuestion{
+				ID:     SampleID1,
+				Text:   "Image Question",
+				FormID: sampleID2,
+				Type:   TypeFile,
+				Customs: map[string]interface{}{
+					FileQuestionFileTypeField: []bool{false, true, false},
+				},
+			},
+			want: NewFileQuestion(SampleID1,
+				"Image Question",
+				FileTypes{
+					AcceptAny:   false,
+					AcceptImage: true,
+					AcceptPDF:   false,
+				}, ImageFileConstraint{}, sampleID2),
+		},
+		{
+			name: "ImageQuestion - With Constraints",
+			from: StandardQuestion{
+				ID:     SampleID1,
+				Text:   "Image Question",
+				FormID: sampleID2,
+				Type:   TypeFile,
+				Customs: map[string]interface{}{
+					FileQuestionFileTypeField: []bool{false, true, false},
+					FileImageConstraintField: map[string]interface{}{
+						FileImageConstraintRatio: map[string]interface{}{
+							FileImageConstraintRatioEq: f1,
+						},
+						FileImageConstraintWidth: map[string]interface{}{
+							FileImageConstraintDimensionMin: v1,
+							FileImageConstraintDimensionMax: v2,
+						},
+						FileImageConstraintHeight: map[string]interface{}{
+							FileImageConstraintDimensionMin: v2,
+							FileImageConstraintDimensionMax: v3,
+						},
+					},
+				},
+			},
+			want: NewFileQuestion(SampleID1,
+				"Image Question",
+				FileTypes{
+					AcceptAny:   false,
+					AcceptImage: true,
+					AcceptPDF:   false,
+				}, ImageFileConstraint{
+					Ratio:     NewRatioSpec(nil, nil, &f1),
+					MinNumber: nil,
+					MaxNumber: nil,
+					Width:     NewDimensionSpec(&v1, &v2, nil),
+					Height:    NewDimensionSpec(&v2, &v3, nil),
+				}, sampleID2),
+		},
+		{
+			name: "ImageQuestion - With Constraints - MinMax",
+			from: StandardQuestion{
+				ID:     SampleID1,
+				Text:   "Image Question",
+				FormID: sampleID2,
+				Type:   TypeFile,
+				Customs: map[string]interface{}{
+					FileQuestionFileTypeField: []bool{false, true, false},
+					FileImageConstraintField: map[string]interface{}{
+						FileImageConstraintRatio: map[string]interface{}{
+							FileImageConstraintRatioMin: f2,
+							FileImageConstraintRatioMax: f3,
+						},
+						FileImageConstraintWidth: map[string]interface{}{
+							FileImageConstraintRatioEq: v1,
+						},
+						FileImageConstraintHeight: map[string]interface{}{
+							FileImageConstraintRatioEq: v2,
+						},
+					},
+				},
+			},
+			want: NewFileQuestion(SampleID1,
+				"Image Question",
+				FileTypes{
+					AcceptAny:   false,
+					AcceptImage: true,
+					AcceptPDF:   false,
+				}, ImageFileConstraint{
+					Ratio:     NewRatioSpec(&f2, &f3, nil),
+					MinNumber: nil,
+					MaxNumber: nil,
+					Width:     NewDimensionSpec(nil, nil, &v1),
+					Height:    NewDimensionSpec(nil, nil, &v2),
+				}, sampleID2),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ImportFileQuestion(tc.from)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want.ID, got.ID)
+			assert.Equal(t, tc.want.Text, got.Text)
+			assert.Equal(t, tc.want.MinNumber, got.MinNumber)
+			assert.Equal(t, tc.want.MaxNumber, got.MaxNumber)
+			assert.Equal(t, tc.want.Width, got.Width)
+			assert.Equal(t, tc.want.Height, got.Height)
+			assert.Equal(t, tc.want.Ratio, got.Ratio)
+		})
+	}
+}

--- a/svc/pkg/domain/model/question/file_test.go
+++ b/svc/pkg/domain/model/question/file_test.go
@@ -9,6 +9,7 @@ import (
 func TestImportFileQuestion(t *testing.T) {
 	f1, f2, f3 := float32(0.5), float32(1.5), float32(3.0)
 	v1, v2, v3 := 100, 200, 300
+	n1, n2 := 3, 5
 	SampleID1, sampleID2 := identity.IssueID(), identity.IssueID()
 	tests := []struct {
 		name string
@@ -112,6 +113,39 @@ func TestImportFileQuestion(t *testing.T) {
 					MaxNumber: nil,
 					Width:     NewDimensionSpec(nil, nil, &v1),
 					Height:    NewDimensionSpec(nil, nil, &v2),
+				}, sampleID2),
+		},
+		{
+			name: "ImageQuestion - With Constraints - MinMaxNumber",
+			from: StandardQuestion{
+				ID:     SampleID1,
+				Text:   "Image Question",
+				FormID: sampleID2,
+				Type:   TypeFile,
+				Customs: map[string]interface{}{
+					FileQuestionFileTypeField: []bool{false, true, false},
+					FileImageConstraintField: map[string]interface{}{
+						FileImageConstraintMinNumber: n1,
+						FileImageConstraintMaxNumber: n2,
+						FileImageConstraintWidth:     map[string]interface{}{},
+						FileImageConstraintHeight:    map[string]interface{}{},
+						FileImageConstraintRatio:     map[string]interface{}{},
+					},
+				},
+			},
+			want: NewFileQuestion(SampleID1,
+				"Image Question",
+				FileTypes{
+					AcceptAny:   false,
+					AcceptImage: true,
+					AcceptPDF:   false,
+				},
+				ImageFileConstraint{
+					Ratio:     NewRatioSpec(nil, nil, nil),
+					MinNumber: &n1,
+					MaxNumber: &n2,
+					Width:     NewDimensionSpec(nil, nil, nil),
+					Height:    NewDimensionSpec(nil, nil, nil),
 				}, sampleID2),
 		},
 	}

--- a/svc/pkg/domain/model/question/file_test.go
+++ b/svc/pkg/domain/model/question/file_test.go
@@ -24,6 +24,11 @@ func TestImportFileQuestion(t *testing.T) {
 				Type:   TypeFile,
 				Customs: map[string]interface{}{
 					FileQuestionFileTypeField: []bool{false, true, false},
+					FileImageConstraintField: map[string]interface{}{
+						FileImageConstraintRatio:  map[string]interface{}{},
+						FileImageConstraintWidth:  map[string]interface{}{},
+						FileImageConstraintHeight: map[string]interface{}{},
+					},
 				},
 			},
 			want: NewFileQuestion(SampleID1,
@@ -121,6 +126,10 @@ func TestImportFileQuestion(t *testing.T) {
 			assert.Equal(t, tc.want.Width, got.Width)
 			assert.Equal(t, tc.want.Height, got.Height)
 			assert.Equal(t, tc.want.Ratio, got.Ratio)
+			export, err := got.Export()
+			if assert.NoError(t, err) {
+				assert.Equal(t, tc.from, *export)
+			}
 		})
 	}
 }

--- a/svc/pkg/domain/model/question/question.go
+++ b/svc/pkg/domain/model/question/question.go
@@ -8,7 +8,7 @@ import (
 type (
 	Type     int
 	Question interface {
-		Export() StandardQuestion
+		Export() (*StandardQuestion, error)
 		GetType() Type
 		AssignID(id.QuestionID) error
 		GetID() id.QuestionID
@@ -59,8 +59,8 @@ func NewType(t string) (Type, error) {
 
 func NewStandardQuestion(
 	t Type, id id.QuestionID, formID id.FormID, text string, customs map[string]interface{},
-) StandardQuestion {
-	return StandardQuestion{
+) *StandardQuestion {
+	return &StandardQuestion{
 		ID:      id,
 		Text:    text,
 		FormID:  formID,

--- a/svc/pkg/domain/model/question/radio_button.go
+++ b/svc/pkg/domain/model/question/radio_button.go
@@ -87,7 +87,7 @@ func ImportRadioButtonsQuestion(q StandardQuestion) (*RadioButtonsQuestion, erro
 	), nil
 }
 
-func (q RadioButtonsQuestion) Export() StandardQuestion {
+func (q RadioButtonsQuestion) Export() (*StandardQuestion, error) {
 	customs := make(map[string]interface{})
 
 	options := make(map[string]string, len(q.Options))
@@ -103,7 +103,7 @@ func (q RadioButtonsQuestion) Export() StandardQuestion {
 	customs[RadioButtonOptionsField] = options
 	customs[RadioButtonOptionsOrderField] = optionsOrder
 
-	return NewStandardQuestion(TypeRadio, q.ID, q.FormID, q.Text, customs)
+	return NewStandardQuestion(TypeRadio, q.ID, q.FormID, q.Text, customs), nil
 }
 
 func (o RadioButtonOptionsOrder) GetOrderedIDs() []RadioButtonOptionID {

--- a/svc/pkg/handler/agent/question.go
+++ b/svc/pkg/handler/agent/question.go
@@ -89,7 +89,12 @@ func (q Question) CreateHandler() gin.HandlerFunc {
 		var checkbox *schemaQ.CheckboxQuestionInfo
 		switch qType {
 		case question.TypeCheckBox:
-			checkQ, err := question.ImportCheckBoxQuestion(res.Question.Export())
+			st, err := res.Question.Export()
+			if err != nil {
+				c.JSON(500, gin.H{"error": err.Error()})
+				return
+			}
+			checkQ, err := question.ImportCheckBoxQuestion(*st)
 			if err != nil {
 				c.JSON(500, gin.H{"error": err.Error()})
 				return
@@ -106,7 +111,12 @@ func (q Question) CreateHandler() gin.HandlerFunc {
 				Options: opts,
 			}
 		case question.TypeRadio:
-			radioQ, err := question.ImportRadioButtonsQuestion(res.Question.Export())
+			st, err := res.Question.Export()
+			if err != nil {
+				c.JSON(500, gin.H{"error": err.Error()})
+				return
+			}
+			radioQ, err := question.ImportRadioButtonsQuestion(*st)
 			if err != nil {
 				c.JSON(500, gin.H{"error": err.Error()})
 				return

--- a/svc/pkg/handler/section/info.go
+++ b/svc/pkg/handler/section/info.go
@@ -62,7 +62,12 @@ func (h Section) InfoHandler() gin.HandlerFunc {
 			}
 			switch target.GetType() {
 			case question.TypeRadio:
-				radioQ, err := question.ImportRadioButtonsQuestion(target.Export())
+				st, err := target.Export()
+				if err != nil {
+					c.JSON(500, gin.H{"error": err.Error()})
+					return
+				}
+				radioQ, err := question.ImportRadioButtonsQuestion(*st)
 				if err != nil {
 					c.JSON(500, gin.H{"error": err.Error()})
 					return
@@ -77,7 +82,12 @@ func (h Section) InfoHandler() gin.HandlerFunc {
 				}
 				respQ.Options = &options
 			case question.TypeCheckBox:
-				checkQ, err := question.ImportCheckBoxQuestion(target.Export())
+				st, err := target.Export()
+				if err != nil {
+					c.JSON(500, gin.H{"error": err.Error()})
+					return
+				}
+				checkQ, err := question.ImportCheckBoxQuestion(*st)
 				if err != nil {
 					c.JSON(500, gin.H{"error": err.Error()})
 					return
@@ -92,17 +102,27 @@ func (h Section) InfoHandler() gin.HandlerFunc {
 				}
 				respQ.Options = &options
 			case question.TypeFile:
-				fileQ, err := question.ImportFileQuestion(target.Export())
+				st, err := target.Export()
 				if err != nil {
 					c.JSON(500, gin.H{"error": err.Error()})
 					return
 				}
-				exts := make([]string, len(fileQ.Constraint.GetExtensions()))
-				for i := range fileQ.Constraint.GetExtensions() {
-					exts[i] = string(fileQ.Constraint.GetExtensions()[i])
+				fileQ, err := question.ImportFileQuestion(*st)
+				if err != nil {
+					c.JSON(500, gin.H{"error": err.Error()})
+					return
+				}
+				exts := make([]string, len(fileQ.ImageFileConstraint.GetExtensions()))
+				for i, e := range fileQ.ImageFileConstraint.GetExtensions() {
+					exts[i] = string(e)
+				}
+				ft := schemaS.FileTypes{
+					AcceptAny:   fileQ.FileTypes.AcceptAny,
+					AcceptImage: fileQ.FileTypes.AcceptImage,
+					AcceptPDF:   fileQ.FileTypes.AcceptPDF,
 				}
 				fConstraint := schemaS.FileConstraint{
-					FileType:   fileQ.Constraint.GetFileType().String(),
+					FileType:   ft,
 					Extensions: exts,
 				}
 				respQ.FileConstraint = &fConstraint

--- a/svc/pkg/infra/reader/question_test.go
+++ b/svc/pkg/infra/reader/question_test.go
@@ -65,7 +65,17 @@ func TestQuestion_GetByID(t *testing.T) {
 				return
 			}
 			if tt.wantErr == nil {
-				assert.Equal(t, tt.want.Export(), (*got).Export())
+				wantE, err := tt.want.Export()
+				if err != nil {
+					t.Errorf("GetByID() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				gotE, err := (*got).Export()
+				if err != nil {
+					t.Errorf("GetByID() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				assert.Equal(t, wantE, gotE)
 				assert.Equal(t, tt.want.GetID(), (*got).GetID())
 				assert.Equal(t, tt.want.GetType(), (*got).GetType())
 				assert.Equal(t, tt.want.GetText(), (*got).GetText())
@@ -162,8 +172,18 @@ func TestQuestion_ListByFormID(t *testing.T) {
 								fmt.Printf("id not equal: %v, %v\n", a.GetID(), b.GetID())
 								equal = false
 							}
-							if reflect.DeepEqual(a.Export().Customs, b.Export().Customs) {
-								fmt.Printf("customs not equal: %v, %v\n", a.Export().Customs, b.Export().Customs)
+							aE, err := a.Export()
+							if err != nil {
+								fmt.Printf("error: %v\n", err)
+								equal = false
+							}
+							bE, err := b.Export()
+							if err != nil {
+								fmt.Printf("error: %v\n", err)
+								equal = false
+							}
+							if reflect.DeepEqual(aE, bE) {
+								fmt.Printf("export not equal: %v, %v\n", aE, bE)
 								equal = false
 							}
 							return equal

--- a/svc/pkg/schema/section/info.go
+++ b/svc/pkg/schema/section/info.go
@@ -26,6 +26,33 @@ type TextConstraint struct {
 }
 
 type FileConstraint struct {
-	FileType   string   `json:"file_type"`
-	Extensions []string `json:"extensions"`
+	FileType        FileTypes        `json:"file_types"`
+	Extensions      []string         `json:"extensions"`
+	ImageConstraint *ImageConstraint `json:"img_constraint,omitempty"`
+}
+
+type FileTypes struct {
+	AcceptAny   bool `json:"any"`
+	AcceptImage bool `json:"image"`
+	AcceptPDF   bool `json:"pdf"`
+}
+
+type ImageConstraint struct {
+	Min    *int          `json:"min"`
+	Max    *int          `json:"max"`
+	Width  DimensionSpec `json:"width"`
+	Height DimensionSpec `json:"height"`
+	Ratio  RatioSpec     `json:"ratio"`
+}
+
+type DimensionSpec struct {
+	Min *int `json:"min"`
+	Max *int `json:"max"`
+	Eq  *int `json:"eq"`
+}
+
+type RatioSpec struct {
+	Min *float32 `json:"min"`
+	Max *float32 `json:"max"`
+	Eq  *float32 `json:"eq"`
 }


### PR DESCRIPTION
- **✨ (model/question)FileTypes instead of FileType**
- **✨ (model/question) FileType as FileConstraint**
- **♻️ (model/question) change signature of FileConstraint Export()**
- **♻️ (model/question) change signature of Question Export()**
- **✨ (model/question) impl multiple FileConstraints for a question**
- **✨ (model/question) ImageFileConstraint with distinctive Implementation**
- **✨ (schema/section) response schema for ImageConstraint FileTypes**
- **✨ (schema/section) Import&Export logic for ImageFileConstraint**
- **💥 (model/question) remove map[FileType]FileConstraint, add ImageFileConstraint**
- **♻️ (model/question) move ImageSpecs to new file**
- **✅ (model/question) TestImportFileQuestion**

| Property            | Value |
|:--------------------|:------|
| Corresponding Issue | #87  |
| Assignee            | @shion1305    |

# PRで実装される機能
- ImageConstraintの新規での実装
- FileQuestion/ConstraintのImport/Export

# PRで修正される機能
- ` map[FileType]FileConstraint` の廃止
- QuestionのExport関数のシグネチャ変更

# レビューをお願いしたいポイント
- 激オモになってしまってごめんなさい...
